### PR TITLE
Support for in-script includes

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -40,6 +40,7 @@ var compileScripts = function(isWatchTask){
         var useMinify = ignores.indexOf("minify") == -1;
 
         return gulp.src(b.scripts)
+        .pipe(plugins.resolveDependencies({ pattern: /\* @require [\s-]*(.*?\.js)/g }))
         .pipe(plugins.plumber(config.errorHandler("scripts")))
         .pipe(plugins.if(useJshint, plugins.jshint()))
         .pipe(plugins.if(useJscs, plugins.jscs()))

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-minify-css": "~0.3.13",
     "gulp-notify": "^2.0.0",
     "gulp-plumber": "~0.6.6",
+    "gulp-resolve-dependencies": "^1.0.1",
     "gulp-sourcemaps": "^1.2.8",
     "gulp-sass": "^2.1.0",
     "gulp-svg-sprite": "~1.2.12",


### PR DESCRIPTION
Supports including JS files in JS files using the @require tag.

Example:
/**
* @require ./slider.js
*/