### PR TITLE
gulp html task

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The following tasks are available:
 * images -	Minifies images defined in: gulp-config.json > bundles > {bundleName} > images
 * icons -	Minifies and generates a svg sprite, from the icons defined in: gulp-config.json > bundles > {bundleName} > icons
 * copy -	Copies the fonts defined in: gulp-config.json > bundles > {bundleName} > fonts
+* hhtml - Looks through the html folder for `@@include`, to then partially replace them when compiling the html file
 * watch
 
   * Runs the scripts, styles, images, icons and fonts task whenever a file has changed. The paths it listens on, is defined in the file gulp/config.json > watch.

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -48,7 +48,8 @@ module.exports = (function () {
                 ],
                 styles: [projectPath + preprocessor + "/master." + preprocessor],
                 images: [projectPath + "images/**/*.{jpg,png,svg,gif}"],
-                icons: [projectPath + "icons/**/*.svg"]
+                icons: [projectPath + "icons/**/*.svg"],
+                html: [projectPath + "html/*.html"]
             }
         ],
 
@@ -102,6 +103,12 @@ module.exports = (function () {
         imagesProgressive: true,
         imagesInterlaced: true,
 
+        // -------------- HTML --------------
+        htmlFileIncludeConfig: {
+            prefix: '@@',
+            basepath: '@file'
+        },
+
         // ------------- Livereload ---------
         livereloadPort: 35729,
         livereloadPaths: [
@@ -114,6 +121,7 @@ module.exports = (function () {
         watchImages: [ projectPath + "images/**/*", projectPath + '!images/icons/*' ],
         watchIcons: [ projectPath + "images/icons/*" ],
         watchFonts: [ projectPath + "fonts/*" ],
+        watchHtml: [ projectPath + "html/**/*" ],
         watchScripts: [
             projectPath + "scripts/**/*.js",
             projectPath + "vendor/**/*.js"
@@ -134,11 +142,11 @@ module.exports = (function () {
         loadTasks: [
             "bower", "typescript", "styles",
             "scripts", "images", "icons",
-            "copy", "watch", "build", 
+            "copy", "watch", "build", "html"
         ],
         buildTasks: [
             "styles", "typescript", "scripts",
-            "images", "icons", "copy", 
+            "images", "icons", "copy", "html"
         ],
 
         // ------------- Return Paths -------------
@@ -148,6 +156,7 @@ module.exports = (function () {
         typescriptPath: typescriptPath,
         enableTypescript: enableTypescript,
         preprocessor: preprocessor,
+        distPath: distPath,
 
         // ---------- Errorhandler ------
         errorHandler: function(taskName)

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -1,0 +1,30 @@
+/*
+    the html task looks through the html files in the html folder, after the prefix @@.
+    This makes it possible to include "partial" html pieces like
+
+    <body>
+        @@include('components/site-header.html')
+    </body>
+*/
+
+var gulp = require('gulp');
+var config = require('../config.js');
+var mergeStream = require('merge-stream');
+var plugins = require('gulp-load-plugins')();
+
+gulp.task('html', function() {
+    var streams = config.bundles.filter(function (b) {
+        return b.html != null;
+    }).map(function (b) {
+        var ignores = b.ignorePlugins != null ? b.ignorePlugins : [];
+
+        console.log(b.name + ' html is being compiled');
+
+        return gulp.src(b.html)
+            .pipe(plugins.plumber(config.errorHandler("html")))
+            .pipe(plugins.fileInclude(config.htmlFileIncludeConfig))
+            .pipe(gulp.dest(config.distPath));
+    });
+
+    return mergeStream(streams);
+});

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -16,6 +16,7 @@ gulp.task('watcher', function () {
     gulp.watch(config.watchImages, ["images"]);
     gulp.watch(config.watchIcons, ["icons"]);
     gulp.watch(config.watchFonts, ["copy"]);
+    gulp.watch(config.watchHtml, ["html"]);
 
     return;
 });

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp-cssnano": "^2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.4.0",
+    "gulp-file-include": "^0.13.7",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "~2.0.0",
     "gulp-less": "~3.0.5",
@@ -79,6 +80,7 @@
   "files": [
     "examples/**/*",
     "gulp",
+    "html/**/*.html",
     "scripts/**/*.js",
     "less/**/*.less",
     "bower.json",


### PR DESCRIPTION
Small html task that looks through HTML files after @@include (and other functions starting with @@). It then compiles the files, pulling in html partials, replacing the @@include lines. Sort of mimics a contentplaceholder/partial from razor.