### PR TITLE
Update novicell.js

### DIFF
--- a/scripts/components/novicell.js
+++ b/scripts/components/novicell.js
@@ -16,9 +16,7 @@ if (typeof (console) === 'undefined') {
     console.log = console.error = console.info = console.debug = console.warn = console.trace = console.dir = console.dirxml = console.group = console.groupEnd = console.time = console.timeEnd = console.assert = console.profile = function () { };
 }
 // Shorthand for console.log
-function cl(d) {
-    return console.log(d);
-}
+var cl = console.log.bind(window.console);
 
 // Init the novicell js lib
 


### PR DESCRIPTION
Fixed: Wrapper cl for console.log was returning linenumber of the cl function in novicell.js and not where it was used