### PR TITLE
Update fractal.js

### DIFF
--- a/fractal/fractal.js
+++ b/fractal/fractal.js
@@ -24,7 +24,7 @@ novicellTheme.addStatic(path.join(__dirname, '../' + config.webPath + 'dist'), '
 
 //Helpers
 //If equals
-instance.handlebars.registerHelper("if", function(conditional, options) {
+instance.handlebars.registerHelper("ifequals", function(conditional, options) {
     if (conditional === options.hash.equals) {
         return options.fn(this);
     } else {


### PR DESCRIPTION
I'd like to be able to use the old if-functionality as well, so couldn't we call it something new instead of overwriting the old if? (e.g. I'd like to be able to check whether a property exists and only then add it to the html, with this new one I can only check whether a property has a specific value, and that is not always what you need).

And also, it might confuse people when you change default handlebars helpers?

the new way of using it will be 
    {{#ifequals sub equals="aaa"}}
        flaf
    {{/ifequals}}