### PR TITLE
Remove unnecessary function call

### DIFF
--- a/assets/scripts/master.js
+++ b/assets/scripts/master.js
@@ -12,7 +12,6 @@ document.addEventListener('DOMContentLoaded', function(){
     novicell.validate.init(); // Init Validation
     novicell.inputMasking.init(); //Init input masking
     novicell.persistentField.init(); //Init persistentField
-    novicell.slider.init(); 
     novicell.topbarRelated.init(); 
     novicell.pageheaderSlider.init();
     novicell.cookieInfo.init(); 


### PR DESCRIPTION
Remove no longer necessary function

novicell.slider.init(); is no longer necessary in the new version of Novicell frontend, now we're using "novicell.pageheaderSlider.init();" or custom sliders functions that you can create on the fractal components

JS 🚀 