### PR TITLE
Remove width 100% on Rows

### DIFF
--- a/patterns/_base/_grid.css
+++ b/patterns/_base/_grid.css
@@ -31,7 +31,6 @@ section {
   display: flex;
   flex-grow: 0;
   flex-shrink: 1;
-  width: 100%;
   flex-direction: row;
   flex-wrap: wrap;
   margin-right: var(--half-gutter-compensation);


### PR DESCRIPTION
Adding the width on 100% the CSS force to have 100% on the element even if you put negative margins, and happens thinks like this:
https://paste.pics/68b8cef3b5a0010dfa0b51167ee087ec