### PR TITLE
gulp-babel downgraded to previous version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "es6-promise": "^4.0.5",
     "glob": "^7.1.2",
     "gulp": "^3.9.1",
-    "gulp-babel": "8.0.0",
+    "gulp-babel": "7.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-favicons": "2.2.7",


### PR DESCRIPTION
In previous updates gulp-babel was updated from 7 to 8:
b0cb351a21237314cb614007ad8f81699c50ae6c

I think that causes an issue in gulp "scripts" task:
https://github.com/Novicell/novicell-frontend/blob/8c55df4c4577524a1f132295d49034690e89ba74/gulp/tasks/scripts.js#L68

There is no issue with the version that was used before (7.0.0).