### PR TITLE
Issue #299: Removed automatic removal of inline fill, stroke and transforms

### DIFF
--- a/config/sprites/sprite.js
+++ b/config/sprites/sprite.js
@@ -28,11 +28,7 @@ const spriteConfig = {
         // Convert style to attributes
         transform: [{
             svgo: {
-                plugins: [{
-                        removeAttrs: {
-                            attrs: '(fill.*|stroke.*|transform.*)'
-                        }
-                    },
+                plugins: [
                     {
                         inlineStyles: true
                     }


### PR DESCRIPTION
I removed the automatic removal of inline attributes, so you now can have multicolored icons.

The catch is that now you need to do this yourself if necessary. 

The reason for doing it anyways, is that when we have issues with an icon, this automatic optimization, most of the times, doesn't fix the issues, so you still need to do manual optimization to the icon anyways.