### PR TITLE
fonts script couldn't handle subdirectories

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test": "echo Working...",
         "fractal": "fractal start --sync",
         "fractal:build": "fractal build",
-        "fonts": "cross-env-shell copyfiles -f \"assets/fonts/*\" $npm_package_config_DIST/fonts -V",
+        "fonts": "cross-env-shell copyfiles -u 2 \"assets/fonts/**/*\" $npm_package_config_DIST/fonts/ -V",
         "images": "node config/images/imagemin.js",
         "sprites": "cross-env-shell node config/sprites/sprite.js -i 'assets/icons/**/**/*.svg' -o $npm_package_config_DIST/icons/icons.svg",
         "styles": "cross-env-shell postcss $npm_package_config_CSS_MODULES --dir $npm_package_config_DIST/css --ext min.css --config config/styles/postcss.config.js",


### PR DESCRIPTION
now the fonts script will make the same structure in the dist/fonts directory as in the assets/fonts directory - including subdirectories