### PR TITLE
Add favicons to netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,4 @@
 [build]
   base    = ""
   publish = "build/"
-  command = "npm run build:prod && npm run fractal:build"
+  command = "npm run generateFavicon && build:prod && npm run fractal:build"


### PR DESCRIPTION
As of `dist`-folder being ignored, we can't get a favicon on netlify.
This makes it run on netlify aswell, adding the icons to the distfolder before adding the dist folder to the build folder, that's deployed to netlify.
Thanks to @hesselberg 