### PR TITLE
Hotfix: Fix stylelint config

### DIFF
--- a/config/styles/stylelint.js
+++ b/config/styles/stylelint.js
@@ -1,10 +1,10 @@
 const stylelint = require('stylelint');
 const stylelintConfig = require('./stylelint.config.js');
 const settings = require('../../config');
-const rootFolder = settings.root_folder;
+const sourceRootFolder = settings.sourceRootFolder;
 const watch = require('glob-watcher');
 
-const watcher = watch([rootFolder + '/test.css', '!./something.js']);
+const watcher = watch([sourceRootFolder + '/**/*css']);
  
 // Listen for the 'change' event to get `path`/`stat`
 // No async completion available because this is the raw chokidar instance
@@ -12,7 +12,7 @@ watcher.on('change', function(pathChanged, stat) {
     stylelint.lint({
         config: stylelintConfig,
         fix: true,
-        configBasedir: rootFolder,
+        configBasedir: sourceRootFolder,
         files: pathChanged
     })
 });


### PR DESCRIPTION
# Hotfix: Fix stylelint config

### Issue
The stylelint loader is set to look at test files instead of the actual css files. 

### Solution
Changed the path to look at src folder instead.